### PR TITLE
Update ServerLoginSuccess packet to respond to <1.7.6 connections correctly

### DIFF
--- a/src/main/java/dev/thomazz/litelimbo/packet/impl/login/ServerLoginSuccess.java
+++ b/src/main/java/dev/thomazz/litelimbo/packet/impl/login/ServerLoginSuccess.java
@@ -21,8 +21,10 @@ public class ServerLoginSuccess implements Packet {
 	public void write(ByteBuf buf, Version version, Direction direction) {
 		if (version.compareTo(Version.MINECRAFT_1_16) >= 0) {
 			MinecraftBufferReader.writeUuidIntArray(buf, uuid);
-		} else {
+		} else if (version.compareTo(Version.MINECRAFT_1_7_6) >= 0) {
 			MinecraftBufferReader.writeString(buf, this.uuid.toString());
+		} else {
+			MinecraftBufferReader.writeString(buf, this.uuid.toString().replace("-", ""));
 		}
 
 		MinecraftBufferReader.writeString(buf, this.username);


### PR DESCRIPTION
Before 1.7.6 CraftBukkit and other forks wrote back ServerLoginSuccess packets to player clients without dashes, because of this proxies that allow <1.7.6 connections expect the response to be 32 bytes not 36 and will bounce the packet.